### PR TITLE
fix an old .desktop file MIME typo

### DIFF
--- a/debian/mu.desktop
+++ b/debian/mu.desktop
@@ -7,5 +7,5 @@ Icon=mu
 Terminal=false
 Categories=AudioVideo;Audio;Music;Player;Qt;
 StartupNotify=false
-MimeType=audio/flac;audio/aac;audio/mp2;audio/mp4;audio/mpeg;audio/x-ape;audio/x-musepack;audio/x-aif;audio/x-aiff;audio/oga;audio/ogg;audio/x-flac+ogg;audiox-vorbis+ogg;audio/x-opus+ogg;audio/x-speex;audio/x-tta;audio/x-wav;audio/x-wavpack;application/x-cue;x-content/audio-player
+MimeType=audio/flac;audio/aac;audio/mp2;audio/mp4;audio/mpeg;audio/x-ape;audio/x-musepack;audio/x-aif;audio/x-aiff;audio/oga;audio/ogg;audio/x-flac+ogg;audio/x-vorbis+ogg;audio/x-opus+ogg;audio/x-speex;audio/x-tta;audio/x-wav;audio/x-wavpack;application/x-cue;x-content/audio-player
 


### PR DESCRIPTION
already forgoten here's another .desktop file need to be update >_<
detail reference: https://github.com/frantic1048/mu-archlinux/commit/8ed1bb6dc3e2be6ebfb75db191c7e2c8eb9a16aa#diff-197c4939bd40a005d2296f87f3a9350eR10